### PR TITLE
add getProfile() & getCounter() accessors;

### DIFF
--- a/lib/perf-monitor.ts
+++ b/lib/perf-monitor.ts
@@ -193,3 +193,17 @@ export function count(name: string, value = 1): void {
     counter.data.inc(value);
   }
 }
+/**
+ * lookup a profile by name
+ * @param name the name of the profile to lookup
+ */
+export function getProfile(name: string): ProfilerDetails|null {
+  return profilerInstances[name];
+}
+/**
+ * lookup a counter by name
+ * @param name the name of the counter to lookup
+ */
+export function getCounter(name: string): CounterDetails|null {
+  return counterInstances[name];
+}


### PR DESCRIPTION
sometimes it is beneficial to be able to inspect the sample set to generate more detailed statistics (standard deviation, variance, etc) or persisting sample sets across reloads by storing them in `localStorage`

This allows you to access them via `perfMonitor.getProfile()` and `perfMonitor.getCounter()`